### PR TITLE
Modify Main Content Width

### DIFF
--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -11,7 +11,7 @@ import { SECTIONS } from "@/constants/sections";
 
 export default function Page() {
   return (
-    <div className="container px-4 md:px-6 flex flex-col gap-10">
+    <div className="container px-4 md:px-6 flex flex-col gap-10 mx-auto max-w-[1100px]">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/app/communities/page.tsx
+++ b/app/communities/page.tsx
@@ -11,7 +11,7 @@ import { SECTIONS } from "@/constants/sections";
 
 export default function Page() {
   return (
-    <div className="container px-4 md:px-6 flex flex-col gap-10">
+    <div className="container px-4 md:px-6 flex flex-col gap-10 mx-auto max-w-[1100px]">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/app/developer-tools/page.tsx
+++ b/app/developer-tools/page.tsx
@@ -11,7 +11,7 @@ import { SECTIONS } from "@/constants/sections";
 
 export default function Page() {
   return (
-    <div className="container px-4 md:px-6 flex flex-col gap-10">
+    <div className="container px-4 md:px-6 flex flex-col gap-10 mx-auto max-w-[1100px]">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/app/frameworks-and-libraries/page.tsx
+++ b/app/frameworks-and-libraries/page.tsx
@@ -11,7 +11,7 @@ import { SECTIONS } from "@/constants/sections";
 
 export default function Page() {
   return (
-    <div className="container px-4 md:px-6 flex flex-col gap-10">
+    <div className="container px-4 md:px-6 flex flex-col gap-10 mx-auto max-w-[1100px]">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/app/learning-resources/page.tsx
+++ b/app/learning-resources/page.tsx
@@ -11,7 +11,7 @@ import { SECTIONS } from "@/constants/sections";
 
 export default function Page() {
   return (
-    <div className="container px-4 md:px-6 flex flex-col gap-10">
+    <div className="container px-4 md:px-6 flex flex-col gap-10 mx-auto max-w-[1100px]">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced page layouts by centering content and setting a maximum width of 1100px across various sections, including Blogs, Communities, Developer Tools, Frameworks and Libraries, and Learning Resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->